### PR TITLE
Add new game hash + base addresses for build ID 11960962

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ artifacts/
 # StyleCop
 StyleCopReport.xml
 
+# Jetbrains tools
+.idea
+
 # Files built by Visual Studio
 *_i.c
 *_p.c

--- a/SRTPluginProviderRE3/GameHashes.cs
+++ b/SRTPluginProviderRE3/GameHashes.cs
@@ -23,6 +23,9 @@ namespace SRTPluginProviderRE3
         // Latest CeroD RT DX11 Build TO-DO
         private static readonly byte[] re3cerod_11047603 = new byte[32] { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 
+        // Build : https://steamdb.info/patchnotes/11960962/
+        private static readonly byte[] re3WW_11960962 = new byte[32] { 0x54, 0x58, 0x2F, 0x13, 0xE6, 0xE7, 0x0C, 0xD3, 0x12, 0x02, 0x9E, 0x8D, 0xAB, 0x6C, 0xAB, 0x88, 0x87, 0x08, 0xAB, 0x2B, 0x14, 0xB9, 0xD2, 0xFD, 0x69, 0x37, 0xFE, 0x39, 0xE1, 0x53, 0xD1, 0xF9 };
+        
         private static void OutputVersionString(byte[] cs)
         {
             StringBuilder sb = new StringBuilder("private static readonly byte[] re3??_00000000 = new byte[32] { ");
@@ -37,7 +40,7 @@ namespace SRTPluginProviderRE3
                 }
             }
 
-            sb.Append(" }");
+            sb.Append(" };");
             Console.WriteLine("Please DM VideoGameRoulette or Squirrelies with the version.log");
             // write output to file
             string filename = "version.log";
@@ -74,6 +77,11 @@ namespace SRTPluginProviderRE3
             {
                 Console.WriteLine("Game Detected! Version: CeroD dx11_non-rt Release");
                 return GameVersion.RE3_CEROD_11047603;
+            }
+            else if (checksum.SequenceEqual(re3WW_11960962))
+            {
+                Console.WriteLine("Game Detected! Version: re3WW_11960962 Release");
+                return GameVersion.RE3_NEW_11960962;
             }
             else
             {

--- a/SRTPluginProviderRE3/GameMemoryRE3Scanner.cs
+++ b/SRTPluginProviderRE3/GameMemoryRE3Scanner.cs
@@ -143,6 +143,17 @@ namespace SRTPluginProviderRE3
                         paMapId = 0x0;
                         return GameVersion.RE3_CEROD_11047603;
                     }
+                case GameVersion.RE3_NEW_11960962:
+                    {
+                        paEnemyManager = 0x09A751D0;
+                        paGameClock = 0x9A651B0;
+                        paGameRankSystem = 0x09A6E718;
+                        paInventoryManager = 0x09A682A0;
+                        paPlayerManager = 0x09A773F8;
+                        paLocationId = 0x9A76560;
+                        paMapId = 0x9A76560;
+                        return GameVersion.RE3_NEW_11960962;
+                    }
             }
 
             // If we made it this far... rest in pepperonis. We have failed to detect any of the correct versions we support and have no idea what pointer addresses to use. Bail out.

--- a/SRTPluginProviderRE3/GameVersion.cs
+++ b/SRTPluginProviderRE3/GameVersion.cs
@@ -7,5 +7,6 @@
         RE3_WW_11026988, // Latest RT DX12 Build
         RE3_CEROD_11047603, // Latest CeroD DX11 Build
         RE3_CEROD_11026646, // Latest CeroD RT DX12 Build
+        RE3_NEW_11960962, // Build : https://steamdb.info/patchnotes/11960962/
     }
 }


### PR DESCRIPTION
# Why this pull request ?

The latest download change the game hash and base addresses.

From 
```
0xf7, 0xf7, 0x07, 0x74, 0x32, 0x43, 0xc0, 0x58, 0xe5, 0x65, 0x7f, 0x27, 0x0b, 0x7f, 0x9f, 0x5d, 0x01, 0x17, 0x4b, 0x0e, 0x2e, 0x5b, 0x67, 0x94, 0x61, 0xc2, 0x39, 0x2a, 0xe8, 0x13, 0x0a, 0x30
```

To
```
0x54, 0x58, 0x2F, 0x13, 0xE6, 0xE7, 0x0C, 0xD3, 0x12, 0x02, 0x9E, 0x8D, 0xAB, 0x6C, 0xAB, 0x88, 0x87, 0x08, 0xAB, 0x2B, 0x14, 0xB9, 0xD2, 0xFD, 0x69, 0x37, 0xFE, 0x39, 0xE1, 0x53, 0xD1, 0xF9
```

So, to avoid plugin crash at startup I add the new game hash and corresponding base addresses.

Related to this [issue](https://github.com/SpeedrunTooling/SRTPluginProviderRE3/issues/7)
